### PR TITLE
Remove redundant dragging logic for right mouse button in InfiniteCanvas

### DIFF
--- a/components/ui/InfiniteCanvas.tsx
+++ b/components/ui/InfiniteCanvas.tsx
@@ -2323,18 +2323,6 @@ export default function InfiniteCanvas() {
                                         ? '#ffffff'
                                         : '#000000'
                                 }
-                                boundBoxFunc={(oldBox, newBox) => {
-                                    // Limit resize
-                                    const maxWidth = 800;
-                                    const maxHeight = 800;
-                                    if (
-                                        newBox.width > maxWidth ||
-                                        newBox.height > maxHeight
-                                    ) {
-                                        return oldBox;
-                                    }
-                                    return newBox;
-                                }}
                             />
                         )}
                     </Layer>

--- a/components/ui/InfiniteCanvas.tsx
+++ b/components/ui/InfiniteCanvas.tsx
@@ -549,12 +549,6 @@ export default function InfiniteCanvas() {
             return;
         }
 
-        if (evt.button === 2) {
-            setIsDragging(true);
-            lastPointerPosition.current = point;
-            return;
-        }
-
         if (evt.button === 0 && eraserMode) {
             setIsErasing(true);
             return;
@@ -1022,7 +1016,7 @@ export default function InfiniteCanvas() {
     };
 
     const handleContextMenu = (e: KonvaEventObject<MouseEvent>) => {
-        e.evt.preventDefault();
+        e.evt.preventDefault(); // Still prevent context menu from showing
     };
 
     const handleTouchStart = (e: KonvaEventObject<TouchEvent>) => {

--- a/components/ui/InfiniteCanvas.tsx
+++ b/components/ui/InfiniteCanvas.tsx
@@ -702,7 +702,8 @@ export default function InfiniteCanvas() {
             !lineSegmentMode &&
             !arrowMode &&
             !rectangleMode &&
-            !circleMode
+            !circleMode &&
+            !textMode
         ) {
             setIsDrawing(true);
             setLines([
@@ -1460,6 +1461,9 @@ export default function InfiniteCanvas() {
         const stage = e.target.getStage();
         if (!stage) return;
 
+        const clickedOnEmpty = e.target === stage;
+        if (!clickedOnEmpty) return;
+
         const point = stage.getPointerPosition();
         if (!point) return;
 
@@ -1473,7 +1477,7 @@ export default function InfiniteCanvas() {
             x: stagePoint.x,
             y: stagePoint.y,
             text: '',
-            fontSize: newTextSize, // Use newTextSize instead of hardcoded value
+            fontSize: newTextSize,
             fill: currentColor,
             id: newId,
         };

--- a/components/ui/InfiniteCanvas.tsx
+++ b/components/ui/InfiniteCanvas.tsx
@@ -1172,7 +1172,16 @@ export default function InfiniteCanvas() {
             return;
         }
 
-        if (!dragModeEnabled && !moveMode && !lineSegmentMode) {
+        if (
+            !dragModeEnabled &&
+            !moveMode &&
+            !lineSegmentMode &&
+            !eraserMode &&
+            !arrowMode &&
+            !rectangleMode &&
+            circleMode &&
+            !textMode
+        ) {
             setIsDrawing(true);
             setLines([
                 ...lines,

--- a/components/ui/InfiniteCanvas.tsx
+++ b/components/ui/InfiniteCanvas.tsx
@@ -475,8 +475,10 @@ export default function InfiniteCanvas() {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.metaKey || e.ctrlKey) {
                 if (e.key === 'z') {
+                    e.preventDefault();
                     undo();
                 } else if (e.key === 'y') {
+                    e.preventDefault();
                     redo();
                 } else if (e.key === 'c') {
                     // Copy selected element

--- a/components/ui/canvasButtons.tsx
+++ b/components/ui/canvasButtons.tsx
@@ -555,7 +555,13 @@ export default function CanvasButtons({
                     </>
                 )}
                 <div>
-                    <Button aria-label="clear-canvas" onClick={clear}>
+                    <Button
+                        aria-label="clear-canvas"
+                        onClick={() => {
+                            clear();
+                            disableAllModes();
+                        }}
+                    >
                         <Trash className="h-4 w-4" />
                     </Button>
                 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Right-clicking on the canvas no longer initiates dragging, enhancing navigation predictability.
  - The context menu remains suppressed, ensuring consistent mouse interactions.
  - Improved keyboard event handling for undo and redo actions, providing better control during projects.

- **New Features**
  - The "clear-canvas" button now also disables all modes when clicked, streamlining the user experience.
  - Drawing initiation conditions expanded to include multiple modes, ensuring more precise drawing control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->