### PR TITLE
Implement element deletion functionality in InfiniteCanvas

### DIFF
--- a/components/ui/InfiniteCanvas.tsx
+++ b/components/ui/InfiniteCanvas.tsx
@@ -471,6 +471,61 @@ export default function InfiniteCanvas() {
         }
     };
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const handleElementDelete = () => {
+        if (!selectedId || !selectedShape) return;
+
+        switch (selectedShape) {
+            case 'line': {
+                const lineIndex = parseInt(selectedId);
+                const updatedLines = lines.filter(
+                    (_, index) => index !== lineIndex,
+                );
+                setLines(updatedLines);
+                addToHistory(updatedLines);
+                break;
+            }
+            case 'text': {
+                const updatedTexts = textElements.filter(
+                    (text) => text.id !== selectedId,
+                );
+                setTextElements(updatedTexts);
+                addToHistory(updatedTexts);
+                break;
+            }
+            case 'rectangle': {
+                const rectIndex = parseInt(selectedId);
+                const updatedRectangles = rectangles.filter(
+                    (_, index) => index !== rectIndex,
+                );
+                setRectangles(updatedRectangles);
+                addToHistory(updatedRectangles);
+                break;
+            }
+            case 'circle': {
+                const circleIndex = parseInt(selectedId);
+                const updatedCircles = circles.filter(
+                    (_, index) => index !== circleIndex,
+                );
+                setCircles(updatedCircles);
+                addToHistory(updatedCircles);
+                break;
+            }
+            case 'image': {
+                const updatedImages = images.filter(
+                    (img) => img.id !== selectedId,
+                );
+                setImages(updatedImages);
+                addToHistory(updatedImages);
+                break;
+            }
+        }
+
+        resetTransformer();
+        setSelectedId(null);
+        setSelectedShape(null);
+    };
+
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.metaKey || e.ctrlKey) {
@@ -494,6 +549,13 @@ export default function InfiniteCanvas() {
                     }
                 }
             }
+
+            if (e.key === 'Delete') {
+                if (moveMode) {
+                    e.preventDefault();
+                    handleElementDelete();
+                }
+            }
         };
 
         window.addEventListener('keydown', handleKeyDown);
@@ -507,6 +569,7 @@ export default function InfiniteCanvas() {
         clipboardItem,
         handleElementCopy,
         handleElementPaste,
+        handleElementDelete,
     ]);
 
     const [stagePos, setStagePos] = useState<Point>({ x: 0, y: 0 });


### PR DESCRIPTION
Add the ability to delete selected elements in the InfiniteCanvas, triggered by the Delete key when in move mode. This enhances user interaction by allowing for easier management of canvas elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled canvas element deletion using the keyboard's "Delete" key. Users can now quickly remove selected shapes, with the canvas state and history automatically updated.
	- Improved interaction handling to ensure smooth deletion and clear selection feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->